### PR TITLE
Fix broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
                         <li><a href="https://goo.gl/o5w9hI" target="_blank">XOSP Sources on GitHub</a>
                         </li>
             <i class="fa fa-github"></i>
-                        <li><a href="https://goo.gl/LhO6u1" target="_blank">XOSP Devices Sources on Github</a>
+                        <li><a href="https://goo.gl/09x3k5" target="_blank">XOSP Devices Sources on Github</a>
                         </li>
             <i class="fa fa-google-plus"></i>
                         <li><a href="https://goo.gl/RZMYRL" target="_blank">Community</a>


### PR DESCRIPTION
Because old URL was pointing at https://github.com/XOSP-Project-Devices, which doesn't exist anymore